### PR TITLE
fix(matrix): custom palette colors not getting displayed

### DIFF
--- a/apps/www/registry/elevenlabs-ui/ui/matrix.tsx
+++ b/apps/www/registry/elevenlabs-ui/ui/matrix.tsx
@@ -517,9 +517,9 @@ export const Matrix = React.forwardRef<HTMLDivElement, MatrixProps>(
         >
           <defs>
             <radialGradient id="matrix-pixel-on" cx="50%" cy="50%" r="50%">
-              <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
-              <stop offset="70%" stopColor="currentColor" stopOpacity="0.85" />
-              <stop offset="100%" stopColor="currentColor" stopOpacity="0.6" />
+              <stop offset="0%" stopColor="var(--matrix-on)" stopOpacity="1" />
+              <stop offset="70%" stopColor="var(--matrix-on)" stopOpacity="0.85" />
+              <stop offset="100%" stopColor="var(--matrix-on)" stopOpacity="0.6" />
             </radialGradient>
 
             <radialGradient id="matrix-pixel-off" cx="50%" cy="50%" r="50%">


### PR DESCRIPTION
**description**
this pr is an attempt to fix #13 by relying for the stop color on the `var(--matrix-on)` instead of the `currentColor` css variable.

**test [amber terminal theme]**
```jsx
<Matrix
    rows={7}
    cols={7}
    frames={getFramesForMatrix(index)}
    pattern={getPatternForMatrix(index)}
    fps={getFps(index)}
    size={10}
    gap={2}
    ariaLabel={`Matrix ${index + 1}`}
    palette={{
      on: "hsl(38 92% 50%)",
      off: "hsl(38 92% 15%)",
    }}
  />
```

**preview**
| state | preview |
| -------|------|
| before | <img width="700" height="521" alt="image" src="https://github.com/user-attachments/assets/1e2411e0-1044-4832-b1c5-3b709ead9026" /> |
| after | <img width="700" height="521" alt="image" src="https://github.com/user-attachments/assets/3be75f6b-33e1-4533-9c30-98fe314dfc10" /> | 