### PR TITLE
fix: fix waveform canvas size in voice button

### DIFF
--- a/apps/www/registry/elevenlabs-ui/ui/voice-button.tsx
+++ b/apps/www/registry/elevenlabs-ui/ui/voice-button.tsx
@@ -165,7 +165,7 @@ export const VoiceButton = React.forwardRef<
 
         <div
           className={cn(
-            "relative flex shrink-0 items-center justify-center overflow-hidden transition-all duration-300",
+            "relative box-content flex shrink-0 items-center justify-center overflow-hidden transition-all duration-300",
             size === "icon"
               ? "absolute inset-0 rounded-sm border-0"
               : "h-5 w-24 rounded-sm border",


### PR DESCRIPTION
|Before|After|
|:-:|:-:|
|<img width="360" height="72" alt="Screen Shot 2025-10-24 at 02 06 41" src="https://github.com/user-attachments/assets/bc84d2fc-6e81-485c-9293-05540627c5f1" />|<img width="360" height="72" alt="Screen Shot 2025-10-24 at 02 07 10" src="https://github.com/user-attachments/assets/a1dbf1cb-398b-4398-8ba1-7f052495d5bd" />|
