### PR TITLE
docs: fix shadcn/ui CLI heading rendering and naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Examples:
 npx @elevenlabs/cli@latest components add orb
 ```
 
-### Alternative: Use with shadcn CLI
+### Alternative: Use with shadcn/ui CLI
+
 You can also install components using the standard shadcn/ui CLI:
 ```bash
 # Install all components


### PR DESCRIPTION
## Problem
The README had issues in the Alternative installation section:
1. The Markdown heading wasn't rendering properly (### was visible)
2. Used "shadcn CLI" instead of "shadcn/ui CLI"

## Solution
Fixed the heading syntax and updated naming for consistency.

## Changes
- Fixed Markdown heading rendering for Alternative section
- Updated CLI reference from "shadcn CLI" to "shadcn/ui CLI"
