### PR TITLE
fix(docs): Fix package name for three types

### DIFF
--- a/apps/www/content/docs/components/orb.mdx
+++ b/apps/www/content/docs/components/orb.mdx
@@ -34,7 +34,7 @@ npx @elevenlabs/cli@latest components add orb
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install @react-three/drei @react-three/fiber three @three/types
+npm install @react-three/drei @react-three/fiber three @types/three
 ```
 
 <Step>Copy and paste the following code into your project.</Step>


### PR DESCRIPTION
Closes #35 by fixing the package name of three types in the orb docs