### PR TITLE
clean: remove unused imported ShimmeringText from conversation-demo

### DIFF
--- a/apps/www/registry/elevenlabs-ui/examples/conversation-demo.tsx
+++ b/apps/www/registry/elevenlabs-ui/examples/conversation-demo.tsx
@@ -12,7 +12,6 @@ import {
 import { Message, MessageContent } from "@/registry/elevenlabs-ui/ui/message"
 import { Orb } from "@/registry/elevenlabs-ui/ui/orb"
 import { Response } from "@/registry/elevenlabs-ui/ui/response"
-import { ShimmeringText } from "@/registry/elevenlabs-ui/ui/shimmering-text"
 
 const allMessages = [
   {


### PR DESCRIPTION

## What

  - Remove unused` ShimmeringText` import from `conversation-demo.tsx`.

 ## Why

  **Before:**

  The component imported `ShimmeringText` but never used it, adding unnecessary bundle weight and causing linter warnings.

  **After:**
  Clean imports with no unused dependencies.