### PR TITLE
refactor: forwardRef is deprecated in React 19

### DIFF
--- a/apps/www/registry/elevenlabs-ui/ui/voice-button.tsx
+++ b/apps/www/registry/elevenlabs-ui/ui/voice-button.tsx
@@ -15,7 +15,11 @@ export type VoiceButtonState =
   | "error"
 
 export interface VoiceButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onError"> {
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onError" | "ref"> {
+  /**
+   * Ref to the button element
+   */
+  ref?: React.Ref<HTMLButtonElement>
   /**
    * Current state of the voice button
    * @default "idle"
@@ -85,28 +89,22 @@ export interface VoiceButtonProps
   disabled?: boolean
 }
 
-export const VoiceButton = React.forwardRef<
-  HTMLButtonElement,
-  VoiceButtonProps
->(
-  (
-    {
-      state = "idle",
-      onPress,
-      label,
-      trailing,
-      icon,
-      variant = "outline",
-      size = "default",
-      className,
-      waveformClassName,
-      feedbackDuration = 1500,
-      disabled,
-      onClick,
-      ...props
-    },
-    ref
-  ) => {
+export const VoiceButton = ({
+  state = "idle",
+  onPress,
+  label,
+  trailing,
+  icon,
+  variant = "outline",
+  size = "default",
+  className,
+  waveformClassName,
+  feedbackDuration = 1500,
+  disabled,
+  onClick,
+  ref,
+  ...props
+}: VoiceButtonProps) => {
     const [showFeedback, setShowFeedback] = React.useState(false)
 
     React.useEffect(() => {
@@ -232,8 +230,5 @@ export const VoiceButton = React.forwardRef<
           )}
         </div>
       </Button>
-    )
-  }
-)
-
-VoiceButton.displayName = "VoiceButton"
+  )
+}


### PR DESCRIPTION
## What

React 19 had deprecated `forwardRef` and we can pass `ref` as prop.  Read more on [React documentation. ](https://react.dev/reference/react/forwardRef)

## Why

React team will not support `forwardRef` in the future release.

## More

React team will publish a codemode to update automatically the components to use `ref` as prop. We still have other components that still use `forwardRef`.