### PR TITLE
feat: display github stars for growth flywheel

### DIFF
--- a/apps/www/components/github-link.tsx
+++ b/apps/www/components/github-link.tsx
@@ -1,17 +1,19 @@
+import { Suspense } from "react"
 import Link from "next/link"
 
 import { siteConfig } from "@/lib/config"
 import { Icons } from "@/components/icons"
 import { Button } from "@/registry/elevenlabs-ui/ui/button"
+import { Skeleton } from "@/registry/elevenlabs-ui/ui/skeleton"
 
 export function GitHubLink() {
   return (
     <Button asChild size="sm" variant="ghost" className="h-8 shadow-none">
       <Link href={siteConfig.links.github} target="_blank" rel="noreferrer">
         <Icons.gitHub />
-        {/* <React.Suspense fallback={<Skeleton className="h-4 w-8" />}>
+        <Suspense fallback={<Skeleton className="h-4 w-8" />}>
           <StarsCount />
-        </React.Suspense> */}
+        </Suspense>
       </Link>
     </Button>
   )


### PR DESCRIPTION
## What

Display GitHub stars next to the logo. 

Initially, I planned to add this as a new component, but I discovered it was already implemented and simply commented out. 

Since there was no explanation for why the code was commented, I went ahead and uncommented it.

## Why

We would encourage new visitors to try the components and the numbers of stars will lead to more engagements as it surpasses 1K.

## Screenshot

<img width="131" height="64" alt="image" src="https://github.com/user-attachments/assets/5552eb40-3807-4e14-af41-08897d053b0b" />


