### PR TITLE
refactor: remove useless assignment from targetIn and targetOut

### DIFF
--- a/apps/www/registry/elevenlabs-ui/ui/orb.tsx
+++ b/apps/www/registry/elevenlabs-ui/ui/orb.tsx
@@ -176,8 +176,9 @@ function Scene({
       u.uOpacity.value = Math.min(1, u.uOpacity.value + delta * 2)
     }
 
-    let targetIn = 0
-    let targetOut = 0.3
+    let targetIn
+    let targetOut
+
     if (modeRef.current === "manual") {
       targetIn = clamp01(
         manualInput ?? inputVolumeRef?.current ?? getInputVolume?.() ?? 0


### PR DESCRIPTION
## What

In the `Orb` component we are assigning initial values to `targetIn` and `targetOut`, however looking at the current conditional flow, we find that we re-assign these values in every block and the initial assignment became useless.

<img width="674" height="526" alt="image" src="https://github.com/user-attachments/assets/2fb5a805-f3d8-4aef-910d-84297fb4a027" />


