### PR TITLE
refactor(audio-player-button): render the PlayButton once

### DIFF
--- a/apps/www/registry/elevenlabs-ui/ui/audio-player.tsx
+++ b/apps/www/registry/elevenlabs-ui/ui/audio-player.tsx
@@ -452,37 +452,24 @@ export function AudioPlayerButton<TData = unknown>({
 }: AudioPlayerButtonProps<TData>) {
   const player = useAudioPlayer<TData>()
 
-  if (!item) {
-    return (
-      <PlayButton
-        {...otherProps}
-        playing={player.isPlaying}
-        onPlayingChange={(shouldPlay) => {
-          if (shouldPlay) {
-            player.play()
-          } else {
-            player.pause()
-          }
-        }}
-        loading={player.isBuffering && player.isPlaying}
-      />
-    )
+  const isActive = item ? player.isItemActive(item.id) : true
+  const isPlaying = isActive && player.isPlaying
+  const isLoading = isActive && player.isBuffering && player.isPlaying
+
+  const handlePlayingChange = (shouldPlay: boolean) => {
+    if (shouldPlay) {
+      player.play(item)
+    } else {
+      player.pause()
+    }
   }
 
   return (
     <PlayButton
       {...otherProps}
-      playing={player.isItemActive(item.id) && player.isPlaying}
-      onPlayingChange={(shouldPlay) => {
-        if (shouldPlay) {
-          player.play(item)
-        } else {
-          player.pause()
-        }
-      }}
-      loading={
-        player.isItemActive(item.id) && player.isBuffering && player.isPlaying
-      }
+      playing={isPlaying}
+      onPlayingChange={handlePlayingChange}
+      loading={isLoading}
     />
   )
 }


### PR DESCRIPTION
## What

In the current implementation of `AudioPlayerButton`, we render the `PlayButton` twice with the same props with only one different conditional prop.

In addition to that, the logic of events and conditions is implemented in inline way which reduces the readability and make it hard for component testing in the future ( No components tests are implemented ).

## Why

1. To avoid duplicated rendering.
2. To extract the logic of events.