### PR TITLE
refactor(audio-player): cache audioRef.current to avoid repeated access to the 'current' property

### DIFF
--- a/apps/www/registry/elevenlabs-ui/ui/audio-player.tsx
+++ b/apps/www/registry/elevenlabs-ui/ui/audio-player.tsx
@@ -217,16 +217,19 @@ export function AudioPlayerProvider<TData = unknown>({
   )
 
   useAnimationFrame(() => {
-    if (audioRef.current) {
-      _setActiveItem(itemRef.current)
-      setReadyState(audioRef.current.readyState)
-      setNetworkState(audioRef.current.networkState)
-      setTime(audioRef.current.currentTime)
-      setDuration(audioRef.current.duration)
-      setPaused(audioRef.current.paused)
-      setError(audioRef.current.error)
-      setPlaybackRateState(audioRef.current.playbackRate)
+    const audio = audioRef.current
+    if (!audio) {
+      return
     }
+
+    _setActiveItem(itemRef.current)
+    setReadyState(audio.readyState)
+    setNetworkState(audio.networkState)
+    setTime(audio.currentTime)
+    setDuration(audio.duration)
+    setPaused(audio.paused)
+    setError(audio.error)
+    setPlaybackRateState(audio.playbackRate)
   })
 
   const isPlaying = !paused


### PR DESCRIPTION
## What

In the current implementation of `useAnimationFrame`, we have repeated access to the `audioRef.current` to update the states.

In the new changes, I cached the reference in a variable ( const ) and reuse it without duplication. In addition to that, I used the [guard clause pattern ](https://refactoring.guru/replace-nested-conditional-with-guard-clauses) to check the `audio` reference.

## Why

1. Remove redundancy reference access.

## Additional

We can also use [object destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring) to extract the properties from `audio` to avoid ( but also check before set ) redundancy. Let me know if you prefer this pattern to follow up with a commit.