### PR TITLE
fix: memoize context values to prevent infinite re-renders

### DIFF
--- a/apps/www/components/active-theme.tsx
+++ b/apps/www/components/active-theme.tsx
@@ -5,6 +5,7 @@ import {
   ReactNode,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react"
 
@@ -40,11 +41,12 @@ export function ActiveThemeProvider({
     }
   }, [activeTheme])
 
-  return (
-    <ThemeContext.Provider value={{ activeTheme, setActiveTheme }}>
-      {children}
-    </ThemeContext.Provider>
+  const value = useMemo(
+    () => ({ activeTheme, setActiveTheme }),
+    [activeTheme, setActiveTheme]
   )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
 }
 
 export function useThemeConfig() {

--- a/apps/www/components/block-viewer.tsx
+++ b/apps/www/components/block-viewer.tsx
@@ -97,21 +97,32 @@ function BlockViewerProvider({
   const resizablePanelRef = React.useRef<ImperativePanelHandle>(null)
   const [iframeKey, setIframeKey] = React.useState(0)
 
+  const value = React.useMemo(
+    () => ({
+      item,
+      view,
+      setView,
+      resizablePanelRef,
+      activeFile,
+      setActiveFile,
+      tree,
+      highlightedFiles,
+      iframeKey,
+      setIframeKey,
+    }),
+    [
+      item,
+      view,
+      resizablePanelRef,
+      activeFile,
+      tree,
+      highlightedFiles,
+      iframeKey,
+    ]
+  )
+
   return (
-    <BlockViewerContext.Provider
-      value={{
-        item,
-        view,
-        setView,
-        resizablePanelRef,
-        activeFile,
-        setActiveFile,
-        tree,
-        highlightedFiles,
-        iframeKey,
-        setIframeKey,
-      }}
-    >
+    <BlockViewerContext.Provider value={value}>
       <div
         id={item.name}
         data-view={view}


### PR DESCRIPTION
## Summary
- Memoize `ActiveThemeProvider` context value with `useMemo` to prevent new object references on every render
- Memoize `BlockViewerProvider` context value with `useMemo` for the same reason
- Consumers now only re-render when the actual context values change

## Why this matters
[#59](https://github.com/elevenlabs/ui/issues/59) reports infinite re-renders on the home page. The reporter traced it via React Profiler to a Context Provider creating new object references per render - this is the classic unmemoized context value pattern.

`ActiveThemeProvider` wraps the entire app in the root layout (`app/layout.tsx`), so every render of that provider triggers a re-render of every consumer in the tree. Wrapping the value in `useMemo` maintains referential equality and breaks the render loop.

## Changes
- `apps/www/components/active-theme.tsx` - wrap `{ activeTheme, setActiveTheme }` in `useMemo`
- `apps/www/components/block-viewer.tsx` - wrap context value object in `React.useMemo`

## Testing
- `pnpm run typecheck` passes
- Build and lint failures are pre-existing on `main` (unrelated `/radio` page data collection error)

Fixes #59

This contribution was developed with AI assistance (Claude Code).