### PR TITLE
refactor: remove useless useMemo hook from CodeTabs component

### DIFF
--- a/apps/www/components/code-tabs.tsx
+++ b/apps/www/components/code-tabs.tsx
@@ -8,9 +8,7 @@ import { Tabs } from "@/registry/elevenlabs-ui/ui/tabs"
 export function CodeTabs({ children }: React.ComponentProps<typeof Tabs>) {
   const [config, setConfig] = useConfig()
 
-  const installationType = React.useMemo(() => {
-    return config.installationType || "cli"
-  }, [config])
+  const installationType = config.installationType || "cli"
 
   return (
     <Tabs


### PR DESCRIPTION
`CodeTabs` component contains a function that's wrapped by `useMemo` while the function itself just return a primitive type `string`.

By definition ( from [React official docs](https://react.dev/reference/react/useMemo#usage) ) `useMemo` is a hook that's used to cache the results between re-renders for **expensive calculation.**

<img width="1854" height="456" alt="image" src="https://github.com/user-attachments/assets/16ffea9f-0924-4385-9cb5-e5b3e9ced2b7" />

Based on the current logic, this is [pure function](https://www.freecodecamp.org/news/what-is-a-pure-function-in-javascript-acb887375dfe/) that returns the installation type ( string ).