### PR TITLE
fix: remove explicit any types in scripts and enable linting

### DIFF
--- a/apps/www/eslint.config.mjs
+++ b/apps/www/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextTypescript from "eslint-config-next/typescript"
 
 const eslintConfig = [
   {
-    ignores: [".source/", "scripts/"],
+    ignores: [".source/"],
   },
   ...nextCoreWebVitals,
   ...nextTypescript,

--- a/apps/www/scripts/build-registry.mts
+++ b/apps/www/scripts/build-registry.mts
@@ -152,7 +152,7 @@ async function cleanupGeneratedPaths() {
       // Build a mapping of source paths to target paths for this block
       const pathMappings = new Map<string, string>()
 
-      json.files.forEach((file: any) => {
+      json.files.forEach((file: string | { path?: string; target?: string }) => {
         if (typeof file === "object" && file.path && file.target) {
           // Map the source registry path to the target path
           const sourcePath = file.path.replace(/^registry\/elevenlabs-ui\//, "")
@@ -160,7 +160,7 @@ async function cleanupGeneratedPaths() {
         }
       })
 
-      json.files = json.files.map((file: any) => {
+      json.files = json.files.map((file: string | { path?: string; target?: string; type?: string }) => {
         if (typeof file === "object" && file.path) {
           // Remove registry/elevenlabs-ui/ prefix
           let cleanPath = file.path.replace(/^registry\/elevenlabs-ui\//, "")
@@ -246,7 +246,7 @@ async function buildAllJson() {
   // Aggregate all dependencies and registryDependencies
   const allDependencies = new Set<string>()
   const allRegistryDependencies = new Set<string>()
-  const allFiles: any[] = []
+  const allFiles: Array<{ path: string; type?: string; target: string; content: string }> = []
 
   // Build path mappings for import rewriting
   const pathMappings = new Map<string, string>()


### PR DESCRIPTION
## Summary

This PR addresses part of #73 by:
1. Replacing explicit `any` types with proper TypeScript types in `build-registry.mts`
2. Removing `scripts/` from ESLint ignores to enable linting

## Changes

### Fixed TypeScript `any` types in `build-registry.mts`

**Line 155** - `forEach` callback:
```typescript
// Before
json.files.forEach((file: any) => {

// After
json.files.forEach((file: string | { path?: string; target?: string }) => {
```

**Line 163** - `map` callback:
```typescript
// Before
json.files = json.files.map((file: any) => {

// After
json.files = json.files.map((file: string | { path?: string; target?: string; type?: string }) => {
```

**Line 249** - `allFiles` array:
```typescript
// Before
const allFiles: any[] = []

// After
const allFiles: Array<{ path: string; type?: string; target: string; content: string }> = []
```

### Enabled linting for scripts directory

Removed `scripts/` from the ESLint ignores in `eslint.config.mjs`:
```typescript
// Before
ignores: [".source/", "scripts/"],

// After
ignores: [".source/"],
```

## Testing

The types are inferred from the actual usage patterns in the code:
- `json.files` can contain either strings or objects with `path`, `target`, and `type` properties
- `allFiles` stores objects with `path`, `type`, `target`, and `content` properties

These changes eliminate the 3 `@typescript-eslint/no-explicit-any` errors mentioned in #73.

## Related

- Part of #73
- This PR completes the "Lint the scripts directory" task
- The "Enable new react-hooks v7 rules" task remains to be done in a separate PR