### PR TITLE
fix: update block viewer copy command to use @elevenlabs/cli

### DIFF
--- a/apps/www/components/block-viewer.tsx
+++ b/apps/www/components/block-viewer.tsx
@@ -221,7 +221,7 @@ function BlockViewerToolbar() {
           size="sm"
           onClick={() => {
             copyToClipboard(
-              `npx shadcn@latest add "https://ui.elevenlabs.io/r/${item.name}.json"`
+              `npx @elevenlabs/cli@latest components add ${item.name}`
             )
           }}
         >


### PR DESCRIPTION
## Summary
- Updates the copy-to-clipboard command in the block viewer toolbar from `npx shadcn@latest add "https://ui.elevenlabs.io/r/..."` to `npx @elevenlabs/cli@latest components add <name>`
- Follow-up to #20

## Test plan
- [x] Verified the change is a single-line string replacement
- [ ] Verify the copied command works correctly when pasted into a terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)